### PR TITLE
Update materialize CSS

### DIFF
--- a/configurator.py
+++ b/configurator.py
@@ -82,7 +82,7 @@ INDEX = Template(r"""<!DOCTYPE html>
     <title>HASS Configurator</title>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/MaterialDesign-Webfont/1.8.36/css/materialdesignicons.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.98.2/css/materialize.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.1/css/materialize.min.css">
     <style type="text/css" media="screen">
         body {
             margin: 0;
@@ -1896,7 +1896,7 @@ INDEX = Template(r"""<!DOCTYPE html>
 <input type="hidden" id="fb_currentfile" value="" />
 <!-- Scripts -->
 <script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.98.2/js/materialize.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.1/js/materialize.min.js"></script>
 <script type="text/javascript">
     $(document).ready(function () {
         $('select').material_select();


### PR DESCRIPTION
Update from version 98.2 to 100.1 (latest)
Latest change log can be found here: [https://github.com/Dogfalo/materialize/releases](url)