### PR TITLE
0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Set this variable to `True` to enable Git integration. This feature requires [Gi
  to be installed on the system that is running the configurator. For thechnical reasons this feature can't be enabled with a static configuration file.  
 To push local commits to a remote repository, you have to add the remote manually: `git remote add origin ssh://somehost:/user/repo.git`  
 Verify, that the user that is running the configurator is allowed to push without any interaction (by using SSH PubKey authentication for example).
+#### DIRSFIRST (bool)
+if set to `true`, directories will be displayed at the top
  
 __Note regarding `ALLOWED_NETWORKS`, `BANNED_IPS` and `BANLIMIT`__:  
 The way this is implemented works in the following order:

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
-Version 0.2.2 (2017-nn-nn)
+Version 0.2.2 (2017-11-01)
 - Added option to list directories first @dimagoltsman
+- Updated dependencies @jmart518
 
 Version 0.2.1 (2017-10-12)
 - Added script reloading

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Version 0.2.2 (2017-nn-nn)
+- Added option to list directories first @dimagoltsman
+
 Version 0.2.1 (2017-10-12)
 - Added script reloading
 

--- a/configurator.py
+++ b/configurator.py
@@ -84,7 +84,7 @@ INDEX = Template(r"""<!DOCTYPE html>
     <title>HASS Configurator</title>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/MaterialDesign-Webfont/2.0.46/css/materialdesignicons.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.1/css/materialize.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/css/materialize.min.css">
     <style type="text/css" media="screen">
         body {
             margin: 0;
@@ -521,9 +521,9 @@ INDEX = Template(r"""<!DOCTYPE html>
         }
 
     </style>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.8/ace.js" type="text/javascript" charset="utf-8"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.8/ext-modelist.js" type="text/javascript" charset="utf-8"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.8/ext-language_tools.js" type="text/javascript" charset="utf-8"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ace.js" type="text/javascript" charset="utf-8"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ext-modelist.js" type="text/javascript" charset="utf-8"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ext-language_tools.js" type="text/javascript" charset="utf-8"></script>
 </head>
 <body>
   <div class="preloader-background">
@@ -1914,7 +1914,7 @@ INDEX = Template(r"""<!DOCTYPE html>
                   <input id="wrap_limit" type="number" onchange="editor.setOption('wrap', parseInt(this.value))" min="1" value="80">
                   <label class="active" for="wrap_limit">Wrap Limit</label>
               </div> <a class="waves-effect waves-light btn light-blue" onclick="save_ace_settings()">Save Settings Locally</a>
-              <p class="center col s12"> Ace Editor 1.2.8 </p>
+              <p class="center col s12"> Ace Editor 1.2.9 </p>
           </div>
         </ul>
       </div>
@@ -1922,7 +1922,7 @@ INDEX = Template(r"""<!DOCTYPE html>
 <input type="hidden" id="fb_currentfile" value="" />
 <!-- Scripts -->
 <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.1/js/materialize.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/js/materialize.min.js"></script>
 <script type="text/javascript">
     $(document).ready(function () {
         $('select').material_select();

--- a/configurator.py
+++ b/configurator.py
@@ -65,7 +65,7 @@ SO.setLevel(LOGLEVEL)
 SO.setFormatter(logging.Formatter('%(levelname)s:%(asctime)s:%(name)s:%(message)s'))
 LOG.addHandler(SO)
 RELEASEURL = "https://api.github.com/repos/danielperna84/hass-configurator/releases/latest"
-VERSION = "0.2.0"
+VERSION = "0.2.2"
 BASEDIR = "."
 DEV = False
 HTTPD = None

--- a/dev.html
+++ b/dev.html
@@ -6,7 +6,7 @@
     <title>HASS Configurator</title>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/MaterialDesign-Webfont/2.0.46/css/materialdesignicons.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.1/css/materialize.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/css/materialize.min.css">
     <style type="text/css" media="screen">
         body {
             margin: 0;
@@ -443,9 +443,9 @@
         }
 
     </style>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.8/ace.js" type="text/javascript" charset="utf-8"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.8/ext-modelist.js" type="text/javascript" charset="utf-8"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.8/ext-language_tools.js" type="text/javascript" charset="utf-8"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ace.js" type="text/javascript" charset="utf-8"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ext-modelist.js" type="text/javascript" charset="utf-8"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ext-language_tools.js" type="text/javascript" charset="utf-8"></script>
 </head>
 <body>
   <div class="preloader-background">
@@ -1836,7 +1836,7 @@
                   <input id="wrap_limit" type="number" onchange="editor.setOption('wrap', parseInt(this.value))" min="1" value="80">
                   <label class="active" for="wrap_limit">Wrap Limit</label>
               </div> <a class="waves-effect waves-light btn light-blue" onclick="save_ace_settings()">Save Settings Locally</a>
-              <p class="center col s12"> Ace Editor 1.2.8 </p>
+              <p class="center col s12"> Ace Editor 1.2.9 </p>
           </div>
         </ul>
       </div>
@@ -1844,7 +1844,7 @@
 <input type="hidden" id="fb_currentfile" value="" />
 <!-- Scripts -->
 <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.1/js/materialize.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/js/materialize.min.js"></script>
 <script type="text/javascript">
     $(document).ready(function () {
         $('select').material_select();

--- a/settings.conf
+++ b/settings.conf
@@ -10,5 +10,6 @@
     "ALLOWED_NETWORKS": [],
     "BANNED_IPS": [],
     "BANLIMIT": 0,
-    "IGNORE_PATTERN": []
+    "IGNORE_PATTERN": [],
+    "DIRSFIRST": false
 }


### PR DESCRIPTION
Currently we have:
- Added option to list directories first

@jmart518 maybe update dependencies?

A feature I have in mind:
Adding allowed IPs / Networks during runtime via POST/GET request. Security could benefit from that for people that currently have set the allowed networks to `0.0.0.0` when they want external access. By using some sort of automation in HASS (which allows `0.0.0.0` as well usually in those cases), people could push their current remote IP to HASS, and from there to the configurator.

Alternatively we could expose a single unprotected (in terms of IP access) API endpoint, which when access with the correct credentials, whitelists the IP the request has originated from. I think I like that even better and it would be much easier for the users.