### PR TITLE
YAML Linter

### DIFF
--- a/configurator.py
+++ b/configurator.py
@@ -526,6 +526,10 @@ INDEX = Template(r"""<!DOCTYPE html>
             top: 0.75rem;
             right: 10px;
         }
+
+        .cursor-pointer {
+            cursor: pointer;
+        }
     </style>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ace.js" type="text/javascript" charset="utf-8"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ext-modelist.js" type="text/javascript" charset="utf-8"></script>
@@ -2743,37 +2747,40 @@ INDEX = Template(r"""<!DOCTYPE html>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/3.10.0/js-yaml.js" type="text/javascript" charset="utf-8"></script>
 <script type="text/javascript">
 var lint_timeout;
+var lint_status = $('#lint-status'); // speed optimization
 
 function check_lint()
 {
-    if ($('#currentfile').val().match(".yaml$")) {
+    if (document.getElementById('currentfile').value.match(".yaml$")) {
         try {
             var text = editor.getValue().replace(/!(include|secret)/g,".$1"); // hack because js-yaml does not like !include/!secret
             jsyaml.safeLoad(text);
-            $('#lint-status').text("check_circle");
-            $('#lint-status').removeClass("red-text blue-text");
-            $('#lint-status').addClass("green-text");
+            lint_status.text("check_circle");
+            lint_status.removeClass("cursor-pointer red-text grey-text");
+            lint_status.addClass("green-text");
         } catch (err) {
-            $('#lint-status').text("error");
-            $('#lint-status').removeClass("green-text blue-text");
-            $('#lint-status').addClass("red-text");
+            lint_status.text("error");
+            lint_status.removeClass("green-text grey-text");
+            lint_status.addClass("cursor-pointer red-text");
             console.log(err);
         }
     } else {
-        $('#lint-status').text("");
+        lint_status.empty();
     }
 }
 
 function queue_lint(e)
 {
-    if ($('#currentfile').val().match(".yaml$")) {
+    if (document.getElementById('currentfile').value.match(".yaml$")) {
         clearTimeout(lint_timeout);
-        $('#lint-status').text("watch_later");
-        $('#lint-status').removeClass("red-text green-text");
-        $('#lint-status').addClass("blue-text");
-        lint_timeout = setTimeout(check_lint, 1000);
+        lint_timeout = setTimeout(check_lint, 500);
+        if (lint_status.text() != "cached") {
+            lint_status.text("cached");
+            lint_status.removeClass("cursor-pointer red-text green-text");
+            lint_status.addClass("grey-text");
+        }
     } else {
-        $('#lint-status').text("");
+        lint_status.empty();
     }
 }
 

--- a/configurator.py
+++ b/configurator.py
@@ -2294,6 +2294,7 @@ INDEX = Template(r"""<!DOCTYPE html>
                 editor.session.getUndoManager().markClean();
                 $('.markdirty').each(function(i, o){o.classList.remove('red');});
                 $('.hidesave').css('opacity', 0);
+                check_lint();
             });
         }
     }
@@ -2776,7 +2777,7 @@ function queue_lint(e)
     }
 }
 
-editor.getSession().on('change', queue_lint);
+editor.on('change', queue_lint);
 </script>
 </body>
 </html>""")

--- a/configurator.py
+++ b/configurator.py
@@ -2741,18 +2741,20 @@ INDEX = Template(r"""<!DOCTYPE html>
 </script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/3.10.0/js-yaml.js" type="text/javascript" charset="utf-8"></script>
 <script type="text/javascript">
-function check_lint(e)
+var lint_timeout;
+
+function check_lint()
 {
     if ($('#currentfile').val().match(".yaml$")) {
         try {
             var text = editor.getValue().replace(/!(include|secret)/g,".$1"); // hack because js-yaml does not like !include/!secret
             jsyaml.safeLoad(text);
             $('#lint-status').text("check_circle");
-            $('#lint-status').removeClass("red-text");
+            $('#lint-status').removeClass("red-text blue-text");
             $('#lint-status').addClass("green-text");
         } catch (err) {
             $('#lint-status').text("error");
-            $('#lint-status').removeClass("green-text");
+            $('#lint-status').removeClass("green-text blue-text");
             $('#lint-status').addClass("red-text");
             console.log(err);
         }
@@ -2760,7 +2762,21 @@ function check_lint(e)
         $('#lint-status').text("");
     }
 }
-editor.getSession().on('change', check_lint);
+
+function queue_lint(e)
+{
+    if ($('#currentfile').val().match(".yaml$")) {
+        clearTimeout(lint_timeout);
+        $('#lint-status').text("watch_later");
+        $('#lint-status').removeClass("red-text green-text");
+        $('#lint-status').addClass("blue-text");
+        lint_timeout = setTimeout(check_lint, 1000);
+    } else {
+        $('#lint-status').text("");
+    }
+}
+
+editor.getSession().on('change', queue_lint);
 </script>
 </body>
 </html>""")

--- a/configurator.py
+++ b/configurator.py
@@ -530,6 +530,15 @@ INDEX = Template(r"""<!DOCTYPE html>
         .cursor-pointer {
             cursor: pointer;
         }
+
+        #modal_lint.modal {
+            width: 80%;
+        }
+
+        #modal_lint textarea {
+            resize: none;
+            height: auto;
+        }
     </style>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ace.js" type="text/javascript" charset="utf-8"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ext-modelist.js" type="text/javascript" charset="utf-8"></script>
@@ -1477,6 +1486,14 @@ INDEX = Template(r"""<!DOCTYPE html>
           <a class=" modal-action modal-close waves-effect btn-flat light-blue-text">OK</a>
         </div>
     </div>
+    <div id="modal_lint" class="modal">
+        <div class="modal-content">
+            <textarea rows="8" readonly></textarea>
+        </div>
+        <div class="modal-footer">
+          <a class="modal-action modal-close waves-effect btn-flat light-blue-text">OK</a>
+        </div>
+    </div>
     <!-- Main Editor Area -->
     <div class="row">
         <div class="col m4 l3 hide-on-small-only">
@@ -1524,7 +1541,7 @@ INDEX = Template(r"""<!DOCTYPE html>
         <div class="col s12 m8 l9">
           <div class="card input-field col s12 grey lighten-4 hoverable pathtip">
               <input class="currentfile_input" value="" id="currentfile" type="text">
-              <i class="material-icons" id="lint-status"></i>
+              <i class="material-icons" id="lint-status" onclick="show_lint_error()"></i>
           </div>
         </div>
         <div class="col s12 m8 l9 z-depth-2" id="editor"></div>
@@ -2748,6 +2765,7 @@ INDEX = Template(r"""<!DOCTYPE html>
 <script type="text/javascript">
 var lint_timeout;
 var lint_status = $('#lint-status'); // speed optimization
+var lint_error = "";
 
 function check_lint()
 {
@@ -2758,11 +2776,13 @@ function check_lint()
             lint_status.text("check_circle");
             lint_status.removeClass("cursor-pointer red-text grey-text");
             lint_status.addClass("green-text");
+            lint_error = "";
         } catch (err) {
             lint_status.text("error");
             lint_status.removeClass("green-text grey-text");
             lint_status.addClass("cursor-pointer red-text");
             console.log(err);
+            lint_error = err.message;
         }
     } else {
         lint_status.empty();
@@ -2781,6 +2801,14 @@ function queue_lint(e)
         }
     } else {
         lint_status.empty();
+    }
+}
+
+function show_lint_error()
+{
+    if(lint_error) {
+        $("#modal_lint textarea").val(lint_error);
+        $("#modal_lint").modal('open');
     }
 }
 

--- a/configurator.py
+++ b/configurator.py
@@ -2781,7 +2781,6 @@ function check_lint()
             lint_status.text("error");
             lint_status.removeClass("green-text grey-text");
             lint_status.addClass("cursor-pointer red-text");
-            console.log(err);
             lint_error = err.message;
         }
     } else {

--- a/configurator.py
+++ b/configurator.py
@@ -521,6 +521,11 @@ INDEX = Template(r"""<!DOCTYPE html>
             100% { background-color: #f5f5f5; }
         }
 
+        #lint-status {
+            position: absolute;
+            top: 0.75rem;
+            right: 10px;
+        }
     </style>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ace.js" type="text/javascript" charset="utf-8"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ext-modelist.js" type="text/javascript" charset="utf-8"></script>
@@ -1515,6 +1520,7 @@ INDEX = Template(r"""<!DOCTYPE html>
         <div class="col s12 m8 l9">
           <div class="card input-field col s12 grey lighten-4 hoverable pathtip">
               <input class="currentfile_input" value="" id="currentfile" type="text">
+              <i class="material-icons" id="lint-status"></i>
           </div>
         </div>
         <div class="col s12 m8 l9 z-depth-2" id="editor"></div>
@@ -2732,6 +2738,29 @@ INDEX = Template(r"""<!DOCTYPE html>
         foldstatus = !foldstatus;
     }
 
+</script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/3.10.0/js-yaml.js" type="text/javascript" charset="utf-8"></script>
+<script type="text/javascript">
+function check_lint(e)
+{
+    if ($('#currentfile').val().match(".yaml$")) {
+        try {
+            var text = editor.getValue().replace(/!(include|secret)/g,".$1"); // hack because js-yaml does not like !include/!secret
+            jsyaml.safeLoad(text);
+            $('#lint-status').text("check_circle");
+            $('#lint-status').removeClass("red-text");
+            $('#lint-status').addClass("green-text");
+        } catch (err) {
+            $('#lint-status').text("error");
+            $('#lint-status').removeClass("green-text");
+            $('#lint-status').addClass("red-text");
+            console.log(err);
+        }
+    } else {
+        $('#lint-status').text("");
+    }
+}
+editor.getSession().on('change', check_lint);
 </script>
 </body>
 </html>""")


### PR DESCRIPTION
This adds a YAML lint to the editor. It automatically check any *.yaml file for errors. It displays a status icon to right of the filename. If it finds any error the icon becomes clickable. When clicked it opens a modal with the parser error. The errors can be a bit cryptic, like with any parser, so a disclaimer above the textarea might be useful a useful addition in the future.