### PR TITLE
0.2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The IP address the service is listening on. By default it is binding to `0.0.0.0
 The port the service is listening on. By default it is using 3218, but you can change this if you need to.
 #### BASEPATH (string)
 It is possible to place configurator.py somewhere else. Set the `BASEPATH` to something like `"/home/homeassistant/.homeassistant"`, and no matter where you are running the configurator from, it will start serving files from there. This is needed if you plan on running the configurator with systemd.
+#### ENFORCE_BASEPATH (bool)
+Set ENFORCE_BASEPATH to `True` to lock the configurator into the basepath and thereby prevent it from opening files outside of the BASEPATH
 #### SSL_CERTIFICATE / SSL_KEY (string)
 If you're using SSL, set the paths to your SSL files here. This is similar to the SSL setup you can do in HASS.
 #### HASS_API (string)

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,7 +5,8 @@ Version 0.2.9 (2018-06-)
 - Cosmetic fix for scaled viewports @danielperna84
 - Added search-function for entities (Issue #99) @danielperna84
 - Updated Ace Editor to 1.3.3
-- Updates jQuery to 3.3.1
+- Updated jQuery to 3.3.1
+- Updated js-yaml to 3.12.0
 
 Version 0.2.8 (2018-04-23)
 - Updated CDN libraries @jmart518

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ Version 0.2.9 (2018-06-)
 - Added ENFORCE_BASEPATH option (Issue #68) @danielperna84
 - Cosmetic fix for scaled viewports @danielperna84
 - Added search-function for entities (Issue #99) @danielperna84
+- Updated Ace Editor to 1.3.3
 
 Version 0.2.8 (2018-04-23)
 - Updated CDN libraries @jmart518

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-Version 0.2.9 (2018-06-)
+Version 0.2.9 (2018-06-22)
 - Material Icons and HASS-help now open in new tab instead of modal (Issues #85 and #34) @danielperna84
 - Open file by URL (Issue #95) @danielperna84
 - Added ENFORCE_BASEPATH option (Issue #68) @danielperna84

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 0.2.9 (2018-06-)
+- Material Icons and HASS-help now open in new tab instead of modal (Issues #85 and #34) @danielperna84
+- Open file by URL (Issue #95) @danielperna84
+
 Version 0.2.8 (2018-04-23)
 - Updated CDN libraries @jmart518
 - Cosmetic improvements @jmart518

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ Version 0.2.9 (2018-06-)
 - Material Icons and HASS-help now open in new tab instead of modal (Issues #85 and #34) @danielperna84
 - Open file by URL (Issue #95) @danielperna84
 - Added ENFORCE_BASEPATH option (Issue #68) @danielperna84
+- Cosmetic fix for scaled viewports @danielperna84
 
 Version 0.2.8 (2018-04-23)
 - Updated CDN libraries @jmart518

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ Version 0.2.9 (2018-06-)
 - Cosmetic fix for scaled viewports @danielperna84
 - Added search-function for entities (Issue #99) @danielperna84
 - Updated Ace Editor to 1.3.3
+- Updates jQuery to 3.3.1
 
 Version 0.2.8 (2018-04-23)
 - Updated CDN libraries @jmart518

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version 0.2.9 (2018-06-)
 - Open file by URL (Issue #95) @danielperna84
 - Added ENFORCE_BASEPATH option (Issue #68) @danielperna84
 - Cosmetic fix for scaled viewports @danielperna84
+- Added search-function for entities (Issue #99) @danielperna84
 
 Version 0.2.8 (2018-04-23)
 - Updated CDN libraries @jmart518

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 Version 0.2.9 (2018-06-)
 - Material Icons and HASS-help now open in new tab instead of modal (Issues #85 and #34) @danielperna84
 - Open file by URL (Issue #95) @danielperna84
+- Added ENFORCE_BASEPATH option (Issue #68) @danielperna84
 
 Version 0.2.8 (2018-04-23)
 - Updated CDN libraries @jmart518

--- a/configurator.py
+++ b/configurator.py
@@ -2114,7 +2114,7 @@ INDEX = Template(r"""<!DOCTYPE html>
 </main>
 <input type="hidden" id="fb_currentfile" value="" />
 <!-- Scripts -->
-<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/js/materialize.min.js"></script>
 <script>
     function ws_connect() {

--- a/configurator.py
+++ b/configurator.py
@@ -578,9 +578,9 @@ INDEX = Template(r"""<!DOCTYPE html>
             height: auto;
         }
     </style>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ace.js" type="text/javascript" charset="utf-8"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ext-modelist.js" type="text/javascript" charset="utf-8"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ext-language_tools.js" type="text/javascript" charset="utf-8"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.3.3/ace.js" type="text/javascript" charset="utf-8"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.3.3/ext-modelist.js" type="text/javascript" charset="utf-8"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.3.3/ext-language_tools.js" type="text/javascript" charset="utf-8"></script>
 </head>
 <body>
   <div class="preloader-background">
@@ -2107,7 +2107,7 @@ INDEX = Template(r"""<!DOCTYPE html>
                   <input id="wrap_limit" type="number" onchange="editor.setOption('wrap', parseInt(this.value))" min="1" value="80">
                   <label class="active" for="wrap_limit">Wrap Limit</label>
               </div> <a class="waves-effect waves-light btn light-blue" onclick="save_ace_settings()">Save Settings Locally</a>
-              <p class="center col s12"> Ace Editor 1.2.9 </p>
+              <p class="center col s12"> Ace Editor 1.3.3 </p>
           </div>
         </ul>
       </div>

--- a/configurator.py
+++ b/configurator.py
@@ -3291,7 +3291,7 @@ INDEX = Template(r"""<!DOCTYPE html>
     }
 
 </script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/3.10.0/js-yaml.js" type="text/javascript" charset="utf-8"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/3.12.0/js-yaml.js" type="text/javascript" charset="utf-8"></script>
 <script type="text/javascript">
 var lint_timeout;
 var lint_status = $('#lint-status'); // speed optimization

--- a/configurator.py
+++ b/configurator.py
@@ -1670,6 +1670,10 @@ INDEX = Template(r"""<!DOCTYPE html>
                 <label>Events</label>
             </div>
             <div class="input-field col s12">
+                <input type="text" id="entities-search" class="autocomplete" placeholder="sensor.example">
+                <label>Search entity</label>
+            </div>
+            <div class="input-field col s12">
                 <select id="entities" onchange="insert(this.value)"></select>
                 <label>Entities</label>
             </div>
@@ -1767,6 +1771,10 @@ INDEX = Template(r"""<!DOCTYPE html>
             <div class="input-field col s12">
               <select id="events_side" onchange="insert(this.value)"></select>
               <label>Events</label>
+            </div>
+            <div class="input-field col s12">
+                <input type="text" id="entities-search_side" class="autocomplete" placeholder="sensor.example">
+                <label>Search entity</label>
             </div>
             <div class="input-field col s12">
               <select id="entities_side" onchange="insert(this.value)"></select>
@@ -2262,6 +2270,28 @@ INDEX = Template(r"""<!DOCTYPE html>
         $(document).on('click', '.drag-target', function(){$('.button-collapse').sideNav('hide');})
         listdir('.');
         document.getElementById('savePrompt').checked = get_save_prompt();
+        var entities_search = new Object();
+        if (states_list) {
+            for (var i = 0; i < states_list.length; i++) {
+                entities_search[states_list[i].attributes.friendly_name + ' (' + states_list[i].entity_id + ')'] = null;
+            }
+        }
+        $('#entities-search').autocomplete({
+            data: entities_search,
+            limit: 40,
+            onAutocomplete: function(val) {
+                insert(val.split("(")[1].split(")")[0]);
+            },
+            minLength: 1,
+        });
+        $('#entities-search_side').autocomplete({
+            data: entities_search,
+            limit: 40,
+            onAutocomplete: function(val) {
+                insert(val.split("(")[1].split(")")[0]);
+            },
+            minLength: 1,
+        });
     });
 </script>
 <script type="text/javascript">

--- a/configurator.py
+++ b/configurator.py
@@ -2423,7 +2423,9 @@ INDEX = Template(r"""<!DOCTYPE html>
             if (!data.error) {
                 renderpath(data);
             }
-            console.log("Permission denied.");
+            else {
+                console.log("Permission denied."); 
+            }
         });
         document.getElementById("slide-out").scrollTop = 0;
     }

--- a/configurator.py
+++ b/configurator.py
@@ -339,7 +339,7 @@ INDEX = Template(r"""<!DOCTYPE html>
             box-shadow: 0 1px 0 0 #03a9f4 !important;
         }
 
-        #modal_acekeyboard, #modal_components, #modal_icons {
+        #modal_acekeyboard {
             top: auto;
             width: 96%;
             min-height: 96%;
@@ -654,8 +654,8 @@ INDEX = Template(r"""<!DOCTYPE html>
     <ul id="dropdown_menu" class="dropdown-content z-depth-4">
         <li><a onclick="localStorage.setItem('new_tab', true);window.open(window.location.href, '_blank');">New tab</a></li>
         <li class="divider"></li>
-        <li><a class="modal-trigger" target="_blank" href="#modal_components">Components</a></li>
-        <li><a class="modal-trigger" target="_blank" href="#modal_icons">Material Icons</a></li>
+        <li><a target="_blank" href="https://home-assistant.io/components/">Components</a></li>
+        <li><a target="_blank" href="https://materialdesignicons.com/">Material Icons</a></li>
         <li><a href="#" data-activates="ace_settings" class="ace_settings-collapse">Editor Settings</a></li>
         <li><a class="modal-trigger" href="#modal_netstat" onclick="get_netstat()">Network status</a></li>
         <li><a class="modal-trigger" href="#modal_about">About HASS-Configurator</a></li>
@@ -700,24 +700,6 @@ INDEX = Template(r"""<!DOCTYPE html>
         <li><a class="modal-trigger" href="#modal_commit" class="nowrap waves-effect">git commit</a></li>
         <li><a class="modal-trigger" href="#modal_push" class="nowrap waves-effect">git push</a></li>
     </ul>
-    <div id="modal_components" class="modal bottom-sheet modal-fixed-footer">
-        <div class="modal-content_nopad">
-            <iframe src="https://home-assistant.io/components/" style="height: 90vh; width: 100vw"> </iframe>
-            <a target="_blank" href="https://home-assistant.io/components/" class="hide-on-med-and-down modal_btn waves-effect btn-large btn-flat left"><i class="material-icons">launch</i></a>
-        </div>
-        <div class="modal-footer">
-            <a class="modal-action modal-close waves-effect btn-flat Right light-blue-text">Close</a>
-        </div>
-    </div>
-    <div id="modal_icons" class="modal bottom-sheet modal-fixed-footer">
-    <div class="modal-content_nopad">
-            <iframe src="https://materialdesignicons.com/" style="height: 90vh; width: 100vw"> </iframe>
-            <a target="_blank" href="https://materialdesignicons.com/" class="hide-on-med-and-down modal_btn waves-effect btn-large btn-flat left"><i class="material-icons">launch</i></a>
-        </div>
-        <div class="modal-footer">
-            <a class="modal-action modal-close waves-effect btn-flat Right light-blue-text">Close</a>
-        </div>
-    </div>
     <div id="modal_acekeyboard" class="modal bottom-sheet modal-fixed-footer">
         <div class="modal-content centered">
         <h4 class="grey-text text-darken-3">Ace Keyboard Shortcuts<i class="mdi mdi-keyboard right grey-text text-darken-3" style="font-size: 2rem;"></i></h4>

--- a/configurator.py
+++ b/configurator.py
@@ -74,7 +74,7 @@ SO.setFormatter(
     logging.Formatter('%(levelname)s:%(asctime)s:%(name)s:%(message)s'))
 LOG.addHandler(SO)
 RELEASEURL = "https://api.github.com/repos/danielperna84/hass-configurator/releases/latest"
-VERSION = "0.2.8"
+VERSION = "0.2.9"
 BASEDIR = "."
 DEV = False
 HTTPD = None

--- a/configurator.py
+++ b/configurator.py
@@ -3348,10 +3348,9 @@ def load_settings(settingsfile):
     return False
 
 def is_safe_path(basedir, path, follow_symlinks=True):
-  if follow_symlinks:
-    return os.path.realpath(path).startswith(basedir)
-
-  return os.path.abspath(path).startswith(basedir)
+    if follow_symlinks:
+        return os.path.realpath(path).startswith(basedir)
+    return os.path.abspath(path).startswith(basedir)
 
 def get_dircontent(path, repo=None):
     dircontent = []

--- a/dev.html
+++ b/dev.html
@@ -2333,7 +2333,9 @@
             if (!data.error) {
                 renderpath(data);
             }
-            console.log("Permission denied.");
+            else {
+                console.log("Permission denied."); 
+            }
         });
         document.getElementById("slide-out").scrollTop = 0;
     }

--- a/dev.html
+++ b/dev.html
@@ -3201,7 +3201,7 @@
     }
 
 </script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/3.10.0/js-yaml.js" type="text/javascript" charset="utf-8"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/3.12.0/js-yaml.js" type="text/javascript" charset="utf-8"></script>
 <script type="text/javascript">
 var lint_timeout;
 var lint_status = $('#lint-status'); // speed optimization

--- a/dev.html
+++ b/dev.html
@@ -565,7 +565,7 @@
   </header>
   <main>
     <ul id="dropdown_menu" class="dropdown-content z-depth-4">
-        <li><a onclick="localStorage.setItem('new_tab', true);window.open(window.location.href, '_blank');">New tab</a></li>
+        <li><a onclick="localStorage.setItem('new_tab', true);window.open(window.location.origin+window.location.pathname, '_blank');">New tab</a></li>
         <li class="divider"></li>
         <li><a target="_blank" href="https://home-assistant.io/components/">Components</a></li>
         <li><a target="_blank" href="https://materialdesignicons.com/">Material Icons</a></li>
@@ -584,7 +584,7 @@
         <li><a class="modal-trigger" href="#modal_exec_command">Execute shell command</a></li>
     </ul>
     <ul id="dropdown_menu_mobile" class="dropdown-content z-depth-4">
-        <li><a onclick="localStorage.setItem('new_tab', true);window.open(window.location.href, '_blank');">New tab</a></li>
+        <li><a onclick="localStorage.setItem('new_tab', true);window.open(window.location.origin+window.location.pathname, '_blank');">New tab</a></li>
         <li class="divider"></li>
         <li><a target="_blank" href="https://home-assistant.io/help/">Help</a></li>
         <li><a target="_blank" href="https://home-assistant.io/components/">Components</a></li>
@@ -2070,6 +2070,7 @@
     }
 </script>
 <script type="text/javascript">
+    var init_loadfile = $loadfile;
     var global_current_filepath = null;
     var global_current_filename = null;
 
@@ -2177,17 +2178,23 @@
     document.addEventListener("DOMContentLoaded", function() {
         $('.preloader-background').delay(800).fadeOut('slow');
         $('.preloader-wrapper').delay(800).fadeOut('slow');
-        if (!localStorage.getItem("new_tab")) {
-            var old_file = localStorage.getItem("current_file");
-            if (old_file) {
-                old_file = JSON.parse(old_file);
-                loadfile(old_file.current_filepath, old_file.current_filename);
-            }
+        if (init_loadfile) {
+            init_loadfile_name = init_loadfile.split('/').pop();
+            loadfile(init_loadfile, init_loadfile_name);
         }
         else {
-            localStorage.removeItem("current_file");
+            if (!localStorage.getItem("new_tab")) {
+                var old_file = localStorage.getItem("current_file");
+                if (old_file) {
+                    old_file = JSON.parse(old_file);
+                    loadfile(old_file.current_filepath, old_file.current_filename);
+                }
+            }
+            else {
+                localStorage.removeItem("current_file");
+            }
+            localStorage.removeItem("new_tab");
         }
-        localStorage.removeItem("new_tab");
     });
 </script>
 <script>

--- a/dev.html
+++ b/dev.html
@@ -488,9 +488,9 @@
             height: auto;
         }
     </style>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ace.js" type="text/javascript" charset="utf-8"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ext-modelist.js" type="text/javascript" charset="utf-8"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ext-language_tools.js" type="text/javascript" charset="utf-8"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.3.3/ace.js" type="text/javascript" charset="utf-8"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.3.3/ext-modelist.js" type="text/javascript" charset="utf-8"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.3.3/ext-language_tools.js" type="text/javascript" charset="utf-8"></script>
 </head>
 <body>
   <div class="preloader-background">
@@ -2017,7 +2017,7 @@
                   <input id="wrap_limit" type="number" onchange="editor.setOption('wrap', parseInt(this.value))" min="1" value="80">
                   <label class="active" for="wrap_limit">Wrap Limit</label>
               </div> <a class="waves-effect waves-light btn light-blue" onclick="save_ace_settings()">Save Settings Locally</a>
-              <p class="center col s12"> Ace Editor 1.2.9 </p>
+              <p class="center col s12"> Ace Editor 1.3.3 </p>
           </div>
         </ul>
       </div>

--- a/dev.html
+++ b/dev.html
@@ -114,7 +114,7 @@
             color: #616161 !important;
             font-weight: 400;
             display: inline-block;
-            width: 185px;
+            width: 182px;
             white-space: nowrap;
             text-overflow: ellipsis;
             cursor: pointer;
@@ -2300,7 +2300,10 @@
 
     function listdir(path) {
         $.get(encodeURI("api/listdir?path=" + path), function(data) {
-            renderpath(data);
+            if (!data.error) {
+                renderpath(data);
+            }
+            console.log("Permission denied.");
         });
         document.getElementById("slide-out").scrollTop = 0;
     }

--- a/dev.html
+++ b/dev.html
@@ -2024,7 +2024,7 @@
 </main>
 <input type="hidden" id="fb_currentfile" value="" />
 <!-- Scripts -->
-<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/js/materialize.min.js"></script>
 <script>
     function ws_connect() {

--- a/dev.html
+++ b/dev.html
@@ -252,7 +252,7 @@
             box-shadow: 0 1px 0 0 #03a9f4 !important;
         }
 
-        #modal_acekeyboard, #modal_components, #modal_icons {
+        #modal_acekeyboard {
             top: auto;
             width: 96%;
             min-height: 96%;
@@ -567,8 +567,8 @@
     <ul id="dropdown_menu" class="dropdown-content z-depth-4">
         <li><a onclick="localStorage.setItem('new_tab', true);window.open(window.location.href, '_blank');">New tab</a></li>
         <li class="divider"></li>
-        <li><a class="modal-trigger" target="_blank" href="#modal_components">Components</a></li>
-        <li><a class="modal-trigger" target="_blank" href="#modal_icons">Material Icons</a></li>
+        <li><a target="_blank" href="https://home-assistant.io/components/">Components</a></li>
+        <li><a target="_blank" href="https://materialdesignicons.com/">Material Icons</a></li>
         <li><a href="#" data-activates="ace_settings" class="ace_settings-collapse">Editor Settings</a></li>
         <li><a class="modal-trigger" href="#modal_netstat" onclick="get_netstat()">Network status</a></li>
         <li><a class="modal-trigger" href="#modal_about">About HASS-Configurator</a></li>
@@ -613,24 +613,6 @@
         <li><a class="modal-trigger" href="#modal_commit" class="nowrap waves-effect">git commit</a></li>
         <li><a class="modal-trigger" href="#modal_push" class="nowrap waves-effect">git push</a></li>
     </ul>
-    <div id="modal_components" class="modal bottom-sheet modal-fixed-footer">
-        <div class="modal-content_nopad">
-            <iframe src="https://home-assistant.io/components/" style="height: 90vh; width: 100vw"> </iframe>
-            <a target="_blank" href="https://home-assistant.io/components/" class="hide-on-med-and-down modal_btn waves-effect btn-large btn-flat left"><i class="material-icons">launch</i></a>
-        </div>
-        <div class="modal-footer">
-            <a class="modal-action modal-close waves-effect btn-flat Right light-blue-text">Close</a>
-        </div>
-    </div>
-    <div id="modal_icons" class="modal bottom-sheet modal-fixed-footer">
-    <div class="modal-content_nopad">
-            <iframe src="https://materialdesignicons.com/" style="height: 90vh; width: 100vw"> </iframe>
-            <a target="_blank" href="https://materialdesignicons.com/" class="hide-on-med-and-down modal_btn waves-effect btn-large btn-flat left"><i class="material-icons">launch</i></a>
-        </div>
-        <div class="modal-footer">
-            <a class="modal-action modal-close waves-effect btn-flat Right light-blue-text">Close</a>
-        </div>
-    </div>
     <div id="modal_acekeyboard" class="modal bottom-sheet modal-fixed-footer">
         <div class="modal-content centered">
         <h4 class="grey-text text-darken-3">Ace Keyboard Shortcuts<i class="mdi mdi-keyboard right grey-text text-darken-3" style="font-size: 2rem;"></i></h4>

--- a/dev.html
+++ b/dev.html
@@ -1580,6 +1580,10 @@
                 <label>Events</label>
             </div>
             <div class="input-field col s12">
+                <input type="text" id="entities-search" class="autocomplete" placeholder="sensor.example">
+                <label>Search entity</label>
+            </div>
+            <div class="input-field col s12">
                 <select id="entities" onchange="insert(this.value)"></select>
                 <label>Entities</label>
             </div>
@@ -1677,6 +1681,10 @@
             <div class="input-field col s12">
               <select id="events_side" onchange="insert(this.value)"></select>
               <label>Events</label>
+            </div>
+            <div class="input-field col s12">
+                <input type="text" id="entities-search_side" class="autocomplete" placeholder="sensor.example">
+                <label>Search entity</label>
             </div>
             <div class="input-field col s12">
               <select id="entities_side" onchange="insert(this.value)"></select>
@@ -2172,6 +2180,28 @@
         $(document).on('click', '.drag-target', function(){$('.button-collapse').sideNav('hide');})
         listdir('.');
         document.getElementById('savePrompt').checked = get_save_prompt();
+        var entities_search = new Object();
+        if (states_list) {
+            for (var i = 0; i < states_list.length; i++) {
+                entities_search[states_list[i].attributes.friendly_name + ' (' + states_list[i].entity_id + ')'] = null;
+            }
+        }
+        $('#entities-search').autocomplete({
+            data: entities_search,
+            limit: 40,
+            onAutocomplete: function(val) {
+                insert(val.split("(")[1].split(")")[0]);
+            },
+            minLength: 1,
+        });
+        $('#entities-search_side').autocomplete({
+            data: entities_search,
+            limit: 40,
+            onAutocomplete: function(val) {
+                insert(val.split("(")[1].split(")")[0]);
+            },
+            minLength: 1,
+        });
     });
 </script>
 <script type="text/javascript">

--- a/settings.conf
+++ b/settings.conf
@@ -2,6 +2,7 @@
     "LISTENIP": "0.0.0.0",
     "LISTENPORT": 3218,
     "BASEPATH": null,
+    "ENFORCE_BASEPATH": false,
     "SSL_CERTIFICATE": null,
     "SSL_KEY": null,
     "HASS_API": "http://127.0.0.1:8123/api/",


### PR DESCRIPTION
A few changes coming up. I'll update this post accordingly.

Changelog:
- Material Icons and HASS-help now open in new tab instead of modal
- Open file by URL
- Added ENFORCE_BASEPATH option
- Cosmetic fix for scaled viewports
- Added search-function for entities
- Updated Ace Editor to 1.3.3
- Updated jQuery to 3.3.1
- Updated js-yaml to 3.12.0

The change regarding the icons and the HASS-help is caused by the issues #85 and #34. Embedding those external sites makes JavaScript blockers throw alerts and may cause the configurator to have issues in case it is used in an environment that's not connected to the internet. Besides that loading the content of those sites generates traffic that can be saved and increases the time it takes to load the configurator. Compared to the actual configuring, the time spent on those two sites doesn't justify the created overhead.

Opening files by URL was requested with issue #95 . The way this is used is by appending `/?loadfile=/path/to/file` to the base URL of the configurator. So for example `https://192.168.1.123:3218/?loadfile=/home/homeassistant/.homeassistant/configuration.yaml`

The `ENFORCE_BASEPATH` was requested in Issue #68 . If `BASEPATH` is set and `ENFORCE_BASEPATH` set to `True`, then it's not possible to browse outsite of the basepath or open files outside. Downloading is blocked as well. Did I miss anything?

Also included: Issue #99 (search-function for entities)