### PR TITLE
Make last file in list visible

### DIFF
--- a/configurator.py
+++ b/configurator.py
@@ -283,6 +283,10 @@ INDEX = Template(r"""<!DOCTYPE html>
             border-bottom: 1px solid #eeeeee !important;
         }
 
+        .side-nav {
+            bottom: 0;
+        }
+
         .fb_side-nav li {
             line-height: 36px;
         }


### PR DESCRIPTION
For some reason the CSS didn't connect the side-nav to the bottom
of the page and this lead to some wrong calculations of the browser
which lead to the fact that the last file in the list of files was
outside of the visible area.

Pinning it with bottom: 0; fixes this problem and now one can scroll
down all the way to even see the last file in the file list.