### PR TITLE
Disable autocomplete on Search entity input

### DIFF
--- a/hass_configurator/dev.html
+++ b/hass_configurator/dev.html
@@ -1603,7 +1603,7 @@
                 <label>Events</label>
             </div>
             <div class="input-field col s12">
-                <input type="text" id="entities-search" class="autocomplete" placeholder="sensor.example">
+                <input type="text" id="entities-search" class="autocomplete" autocomplete="off" placeholder="sensor.example">
                 <label>Search entity</label>
             </div>
             <div class="input-field col s12">


### PR DESCRIPTION
The native autocomplete shows up for this field which covers up the html suggestions