### PR TITLE
Allow for parens in entity friendly names

### DIFF
--- a/hass_configurator/dev.html
+++ b/hass_configurator/dev.html
@@ -1810,7 +1810,7 @@
             data: entities_search,
             limit: 40,
             onAutocomplete: function(val) {
-                insert(val.split("(")[1].split(")")[0]);
+                insert(val.split("(").pop().split(")")[0]);
             },
             minLength: 1,
         });
@@ -1818,7 +1818,7 @@
             data: entities_search,
             limit: 40,
             onAutocomplete: function(val) {
-                insert(val.split("(")[1].split(")")[0]);
+                insert(val.split("(").pop().split(")")[0]);
             },
             minLength: 1,
         });


### PR DESCRIPTION
Selects the last encountered '('-split instead of the second, allowing for parenthesis in friendly entity names.

Fixes https://github.com/home-assistant/addons/issues/2779

A bit dirty. Actual entity names should be put as data-attributes in the elements and not be extracted from the shown text, but this patch is minimally invasive.