### PR TITLE
Add dark mode with auto/light/dark toggle and server-side persistence

### DIFF
--- a/hass_configurator/configurator.py
+++ b/hass_configurator/configurator.py
@@ -118,6 +118,35 @@ TOTP = None
 HTTPD = None
 FAIL2BAN_IPS = {}
 REPO = None
+PREFS_FILENAME = ".hass_configurator_prefs.json"
+DEFAULT_PREFS = {"ui_theme": "auto"}
+
+def get_prefs_path():
+    """Return the path for the preferences file (in BASEPATH or BASEDIR)."""
+    base = BASEPATH if BASEPATH else BASEDIR
+    return os.path.join(base, PREFS_FILENAME)
+
+def load_prefs():
+    """Load UI preferences from disk, return defaults on any error."""
+    try:
+        with open(get_prefs_path(), 'r') as fptr:
+            data = json.loads(fptr.read())
+            # Ensure all default keys exist
+            for k, v in DEFAULT_PREFS.items():
+                data.setdefault(k, v)
+            return data
+    except Exception:
+        return dict(DEFAULT_PREFS)
+
+def save_prefs(prefs):
+    """Persist UI preferences to disk."""
+    try:
+        with open(get_prefs_path(), 'w') as fptr:
+            fptr.write(json.dumps(prefs))
+        return True
+    except Exception as err:
+        LOG.warning("Could not save preferences: %s", err)
+        return False
 
 ERROR_HTML = """<!DOCTYPE html>
 <html lang="en">
@@ -633,6 +662,11 @@ class RequestHandler(BaseHTTPRequestHandler):
                 if os.path.isdir(dirpath):
                     self.wfile.write(os.path.abspath(os.path.dirname(dirpath)))
             return
+        elif req.path.endswith('/api/prefs'):
+            self.send_header('Content-type', 'text/json')
+            self.end_headers()
+            self.wfile.write(bytes(json.dumps(load_prefs()), "utf8"))
+            return
         elif req.path.endswith('/api/netstat'):
             content = ""
             self.send_header('Content-type', 'text/json')
@@ -872,7 +906,8 @@ class RequestHandler(BaseHTTPRequestHandler):
                     hass_api_address="%s" % (HASS_API, ),
                     hass_ws_address=ws_api,
                     api_password=HASS_API_PASSWORD if HASS_API_PASSWORD else "",
-                    standalone=standalone)
+                    standalone=standalone,
+                    ui_theme=load_prefs().get('ui_theme', 'auto'))
             except Exception as err:
                 LOG.warning("Error getting html: %s", err)
                 html = ERROR_HTML
@@ -1565,6 +1600,30 @@ class RequestHandler(BaseHTTPRequestHandler):
                         LOG.warning(err)
             else:
                 response['message'] = "Missing IP"
+        elif req.path.endswith('/api/prefs'):
+            try:
+                body = self.rfile.read(length).decode('utf-8')
+                new_prefs = json.loads(body)
+            except Exception as err:
+                LOG.warning(err)
+                new_prefs = {}
+            if 'ui_theme' in new_prefs:
+                theme = new_prefs['ui_theme']
+                if theme in ('light', 'dark', 'auto'):
+                    prefs = load_prefs()
+                    prefs['ui_theme'] = theme
+                    ok = save_prefs(prefs)
+                    self.send_response(200)
+                    self.send_header('Content-type', 'text/json')
+                    self.end_headers()
+                    response['error'] = not ok
+                    response['message'] = "Preferences saved" if ok else "Could not write prefs file"
+                    self.wfile.write(bytes(json.dumps(response), "utf8"))
+                    return
+                else:
+                    response['message'] = "Invalid theme value"
+            else:
+                response['message'] = "Missing ui_theme"
         else:
             response['message'] = "Invalid method"
         self.send_response(200)

--- a/hass_configurator/dev.html
+++ b/hass_configurator/dev.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="$ui_theme">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0" />
@@ -90,6 +90,8 @@
     <ul id="dropdown_menu" class="dropdown-content z-depth-4">
         <li><a onclick="localStorage.setItem('new_tab', true);window.open(window.location.origin+window.location.pathname, '_blank');">New tab</a></li>
         <li class="divider"></li>
+        <li><a onclick="cycleTheme()" id="theme_toggle_item"><i class="material-icons" style="vertical-align:middle;margin-right:8px;font-size:18px;" id="theme_toggle_icon">brightness_auto</i><span id="theme_toggle_label">Theme: Auto</span></a></li>
+        <li class="divider"></li>
         <li><a target="_blank" href="https://home-assistant.io/components/">Components</a></li>
         <li><a target="_blank" href="https://materialdesignicons.com/">Material Icons</a></li>
         <li><a href="#" data-activates="ace_settings" class="ace_settings-collapse">Editor Settings</a></li>
@@ -110,6 +112,8 @@
     </ul>
     <ul id="dropdown_menu_mobile" class="dropdown-content z-depth-4">
         <li><a onclick="localStorage.setItem('new_tab', true);window.open(window.location.origin+window.location.pathname, '_blank');">New tab</a></li>
+        <li class="divider"></li>
+        <li><a onclick="cycleTheme()"><i class="material-icons" style="vertical-align:middle;margin-right:8px;font-size:18px;" id="theme_toggle_icon_mobile">brightness_auto</i><span id="theme_toggle_label_mobile">Theme: Auto</span></a></li>
         <li class="divider"></li>
         <li><a target="_blank" href="https://home-assistant.io/help/">Help</a></li>
         <li><a target="_blank" href="https://home-assistant.io/components/">Components</a></li>
@@ -2938,6 +2942,115 @@
     }
 
     apply_settings();
+
+
+    /* ============================================================
+       Theme management – persisted server-side via /api/prefs
+       Modes: "auto" | "light" | "dark"
+       ============================================================ */
+
+    var THEME_MODES = ['auto', 'light', 'dark'];
+    var THEME_LABELS = {
+        'auto':  'Theme: Auto',
+        'light': 'Theme: Light',
+        'dark':  'Theme: Dark'
+    };
+    var THEME_ICONS = {
+        'auto':  'brightness_auto',
+        'light': 'brightness_high',
+        'dark':  'brightness_2'
+    };
+    // Best matching Ace themes for each UI mode
+    var ACE_THEMES = {
+        'light': 'ace/theme/chrome',
+        'dark':  'ace/theme/monokai'
+    };
+
+    function _isSystemDark() {
+        return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    }
+
+    function _resolvedMode(mode) {
+        // Resolve "auto" to the actual rendered mode
+        if (mode === 'auto') return _isSystemDark() ? 'dark' : 'light';
+        return mode;
+    }
+
+    function applyTheme(mode, saveToServer) {
+        // Set data-theme on <html>: "dark", "light", or remove for auto CSS
+        var html = document.documentElement;
+        if (mode === 'auto') {
+            html.removeAttribute('data-theme');
+        } else {
+            html.setAttribute('data-theme', mode);
+        }
+
+        // Sync Ace editor theme to resolved mode
+        try {
+            var resolved = _resolvedMode(mode);
+            editor.setTheme(ACE_THEMES[resolved]);
+            // Update the theme <select> in Editor Settings if it exists
+            var themeSelect = document.getElementById('theme');
+            if (themeSelect) {
+                themeSelect.value = ACE_THEMES[resolved];
+            }
+        } catch(e) {}
+
+        // Update toggle labels and icons (desktop + mobile)
+        var label  = THEME_LABELS[mode]  || 'Theme';
+        var icon   = THEME_ICONS[mode]   || 'brightness_auto';
+        ['theme_toggle_label', 'theme_toggle_label_mobile'].forEach(function(id) {
+            var el = document.getElementById(id);
+            if (el) el.textContent = label;
+        });
+        ['theme_toggle_icon', 'theme_toggle_icon_mobile'].forEach(function(id) {
+            var el = document.getElementById(id);
+            if (el) el.textContent = icon;
+        });
+
+        // Persist to server so all devices get the same setting
+        if (saveToServer) {
+            $.ajax({
+                url: 'api/prefs',
+                type: 'POST',
+                contentType: 'application/json',
+                data: JSON.stringify({ui_theme: mode}),
+                success: function(resp) {
+                    if (resp.error) {
+                        Materialize.toast('Could not save theme preference: ' + resp.message, 3000);
+                    }
+                },
+                error: function() {
+                    Materialize.toast('Could not save theme preference', 3000);
+                }
+            });
+        }
+    }
+
+    function cycleTheme() {
+        var current = document.documentElement.getAttribute('data-theme') || 'auto';
+        // Normalise: if attribute missing it is "auto"
+        if (!THEME_MODES.includes(current)) current = 'auto';
+        var next = THEME_MODES[(THEME_MODES.indexOf(current) + 1) % THEME_MODES.length];
+        applyTheme(next, true);
+    }
+
+    // Apply the server-supplied theme immediately (already set as data-theme on
+    // <html> at server render time, so no flash). Just sync Ace + labels.
+    (function() {
+        var initialMode = document.documentElement.getAttribute('data-theme') || 'auto';
+        applyTheme(initialMode, false);
+
+        // Also react when the OS switches dark/light while the tab is open
+        if (window.matchMedia) {
+            window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function() {
+                var current = document.documentElement.getAttribute('data-theme') || 'auto';
+                if (current === 'auto' || !current) {
+                    applyTheme('auto', false);
+                }
+            });
+        }
+    })();
 
     function save_ace_settings() {
         localStorage.pochass = JSON.stringify(editor.getOptions())

--- a/hass_configurator/style.css
+++ b/hass_configurator/style.css
@@ -1,7 +1,112 @@
+/* ============================================================
+   CSS Custom Properties – Light (default) and Dark themes
+   The [data-theme] attribute is set on <html> by JS on load.
+   "auto" mode relies on prefers-color-scheme only.
+   ============================================================ */
+
+:root {
+    --bg:              #fafafa;
+    --bg-alt:          #f5f5f5;
+    --surface:         #ffffff;
+    --surface-alt:     #eeeeee;
+    --border:          #eeeeee;
+    --nav-bg:          #03a9f4;   /* light-blue */
+    --nav-text:        #ffffff;
+    --sidebar-bg:      #ffffff;
+    --sidebar-text:    #616161;
+    --sidebar-header:  #424242;
+    --sidebar-border:  #eeeeee;
+    --sidebar-hover:   #e0e0e0;
+    --text:            #616161;
+    --text-dark:       #424242;
+    --text-muted:      #757575;
+    --dropdown-bg:     #ffffff;
+    --dropdown-text:   #616161;
+    --modal-bg:        #ffffff;
+    --modal-text:      #616161;
+    --input-border:    #03a9f4;
+    --accent:          #03a9f4;
+    --accent-hover:    #0288d1;
+    --search-bg:       #eeeeee;
+    --search-form-bg:  #fafafa;
+    --search-text:     #424242;
+    --ace-search-bg:   #eeeeee;
+    --shadow-color:    rgba(0,0,0,0.14);
+}
+
+/* Dark theme values */
+[data-theme="dark"] {
+    --bg:              #1e1e1e;
+    --bg-alt:          #252525;
+    --surface:         #2d2d2d;
+    --surface-alt:     #333333;
+    --border:          #3a3a3a;
+    --nav-bg:          #1a1a2e;
+    --nav-text:        #e0e0e0;
+    --sidebar-bg:      #252525;
+    --sidebar-text:    #b0b0b0;
+    --sidebar-header:  #cccccc;
+    --sidebar-border:  #3a3a3a;
+    --sidebar-hover:   #383838;
+    --text:            #b0b0b0;
+    --text-dark:       #cccccc;
+    --text-muted:      #888888;
+    --dropdown-bg:     #2d2d2d;
+    --dropdown-text:   #b0b0b0;
+    --modal-bg:        #2d2d2d;
+    --modal-text:      #cccccc;
+    --input-border:    #4fc3f7;
+    --accent:          #4fc3f7;
+    --accent-hover:    #29b6f6;
+    --search-bg:       #333333;
+    --search-form-bg:  #2d2d2d;
+    --search-text:     #cccccc;
+    --ace-search-bg:   #333333;
+    --shadow-color:    rgba(0,0,0,0.4);
+}
+
+/* Auto dark mode via system preference (only when no explicit theme is set) */
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]):not([data-theme="dark"]) {
+        --bg:              #1e1e1e;
+        --bg-alt:          #252525;
+        --surface:         #2d2d2d;
+        --surface-alt:     #333333;
+        --border:          #3a3a3a;
+        --nav-bg:          #1a1a2e;
+        --nav-text:        #e0e0e0;
+        --sidebar-bg:      #252525;
+        --sidebar-text:    #b0b0b0;
+        --sidebar-header:  #cccccc;
+        --sidebar-border:  #3a3a3a;
+        --sidebar-hover:   #383838;
+        --text:            #b0b0b0;
+        --text-dark:       #cccccc;
+        --text-muted:      #888888;
+        --dropdown-bg:     #2d2d2d;
+        --dropdown-text:   #b0b0b0;
+        --modal-bg:        #2d2d2d;
+        --modal-text:      #cccccc;
+        --input-border:    #4fc3f7;
+        --accent:          #4fc3f7;
+        --accent-hover:    #29b6f6;
+        --search-bg:       #333333;
+        --search-form-bg:  #2d2d2d;
+        --search-text:     #cccccc;
+        --ace-search-bg:   #333333;
+        --shadow-color:    rgba(0,0,0,0.4);
+    }
+}
+
+/* ============================================================
+   Base layout
+   ============================================================ */
+
 body {
     margin: 0;
     padding: 0;
-    background-color: #fafafa;
+    background-color: var(--bg);
+    color: var(--text);
     display: flex;
     min-height: 100vh;
     flex-direction: column;
@@ -11,50 +116,235 @@ main {
     flex: 1 0 auto;
 }
 
-#editor {
-    position: fixed;
-    top: 135px;
-    right: 0;
-    bottom: 0;
+/* ============================================================
+   Navbar / Toolbar
+   Override Materialize .light-blue with maximum specificity
+   ============================================================ */
+
+nav,
+nav.light-blue,
+.navbar-fixed nav,
+.navbar-fixed nav.light-blue,
+header .navbar-fixed nav,
+header nav {
+    background-color: var(--nav-bg) !important;
+    color: var(--nav-text) !important;
+    box-shadow: 0 2px 4px var(--shadow-color) !important;
 }
 
-@media only screen and (max-width: 600px) {
-  #editor {
-      top: 125px;
-  }
-  .toolbar_mobile {
-      margin-bottom: 0;
-  }
+nav a,
+nav .nav-wrapper a,
+nav i.material-icons,
+nav .nav-wrapper i.material-icons,
+.navbar-fixed nav a,
+.navbar-fixed nav i {
+    color: var(--nav-text) !important;
 }
 
-.leftellipsis {
-    overflow: hidden;
-    direction: rtl;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+/* Filepath bar / current file input area */
+.nav-wrapper .input-field input,
+nav .input-field input,
+nav input {
+    color: var(--nav-text) !important;
+    border-bottom-color: var(--nav-text) !important;
 }
 
-.select-wrapper input.select-dropdown {
-    width: 96%;
-    overflow: hidden;
-    direction: ltr;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+/* Active / hover states in nav */
+nav ul a:hover,
+nav ul li.active a {
+    background-color: rgba(255,255,255,0.15) !important;
 }
 
-#edit_float {
-      z-index: 10;
+/* ============================================================
+   Override ALL Materialize grey/white utility classes
+   These are hardcoded in HTML and beat our CSS variables
+   ============================================================ */
+
+.grey.lighten-4,
+.grey.lighten-3,
+.grey.lighten-2,
+.grey.lighten-1,
+ul.grey.lighten-4,
+div.grey.lighten-4,
+li.grey.lighten-4 {
+    background-color: var(--surface) !important;
 }
+
+/* Filepath card bar */
+.card.grey.lighten-4,
+.card.input-field.grey.lighten-4,
+div.card.input-field.col.grey.lighten-4 {
+    background-color: var(--surface-alt) !important;
+    box-shadow: none !important;
+}
+
+/* Filepath input text */
+.currentfile_input,
+input#currentfile {
+    color: var(--text-dark) !important;
+    background-color: transparent !important;
+}
+
+/* Sidebar toolbar rows */
+ul.row.no-padding.center.grey.lighten-4,
+ul.row.center.toolbar_mobile.grey.lighten-4,
+#slide-out.grey.lighten-4,
+ul#slide-out.side-nav.grey.lighten-4 {
+    background-color: var(--sidebar-bg) !important;
+}
+
+/* Grey icons in sidebar toolbar */
+.grey-text.text-darken-2,
+i.grey-text.text-darken-2 {
+    color: var(--text-muted) !important;
+}
+
+/* Tables in modals */
+table,
+table.bordered,
+table.highlight,
+table thead,
+table tbody tr {
+    background-color: var(--modal-bg) !important;
+    color: var(--modal-text) !important;
+    border-color: var(--border) !important;
+}
+
+table.highlight tbody tr:hover {
+    background-color: var(--surface-alt) !important;
+}
+
+/* Card panels */
+.card-panel {
+    background-color: var(--surface) !important;
+    color: var(--text) !important;
+}
+
+/* Chips / badges */
+.chip {
+    background-color: var(--surface-alt) !important;
+    color: var(--text) !important;
+}
+
+/* ============================================================
+   HA Entities panel (left column: Trigger platforms, Events…)
+   ============================================================ */
+
+#hass_menu_l {
+    background-color: var(--bg) !important;
+    color: var(--text) !important;
+}
+
+/* Native <select> elements */
+select,
+select option {
+    background-color: var(--surface) !important;
+    color: var(--text-dark) !important;
+    border-color: var(--border) !important;
+}
+
+/* Materialize styled select dropdowns (the UL overlay) */
+ul.select-dropdown,
+ul.select-dropdown li,
+ul.select-dropdown li span,
+.select-dropdown.dropdown-content,
+.select-dropdown.dropdown-content li,
+.select-dropdown.dropdown-content li span {
+    background-color: var(--dropdown-bg) !important;
+    color: var(--dropdown-text) !important;
+}
+
+.select-dropdown.dropdown-content li:hover,
+.select-dropdown.dropdown-content li.selected {
+    background-color: var(--surface-alt) !important;
+}
+
+/* Materialize input-field label colors */
+.input-field label,
+.input-field .label-icon {
+    color: var(--text-muted) !important;
+}
+
+.input-field label.active {
+    color: var(--accent) !important;
+}
+
+/* Autocomplete dropdown */
+.autocomplete-content,
+.autocomplete-content li,
+.autocomplete-content li span {
+    background-color: var(--dropdown-bg) !important;
+    color: var(--dropdown-text) !important;
+}
+
+/* Editor Settings subheader */
+li.grey.lighten-3.subheader,
+.subheader {
+    background-color: var(--surface-alt) !important;
+    color: var(--text-muted) !important;
+}
+
+/* Branch selector dropdown */
+ul#branches.grey.lighten-4,
+ul.branch_select.grey.lighten-4 {
+    background-color: var(--surface) !important;
+}
+
+/* About / action cards (grey lighten-3) */
+.card.grey.lighten-3,
+div.card.grey.lighten-3 {
+    background-color: var(--surface) !important;
+    color: var(--text) !important;
+}
+
+/* Generic .card */
+.card,
+.card .card-content,
+.card .card-action {
+    background-color: var(--surface) !important;
+    color: var(--text) !important;
+}
+
+/* Preloader overrides for dark bg */
+.preloader-background {
+    background-color: var(--bg) !important;
+}
+
+/* ============================================================
+   Dropdowns
+   ============================================================ */
+
+.dropdown-content {
+    background-color: var(--dropdown-bg) !important;
+}
+
+.dropdown-content li > a,
+.dropdown-content li > span {
+    color: var(--dropdown-text) !important;
+}
+
+.dropdown-content li:hover,
+.dropdown-content li > a:hover {
+    background-color: var(--surface-alt) !important;
+}
+
+.dropdown-content .divider {
+    background-color: var(--border) !important;
+}
+
+/* ============================================================
+   Sidebar / Filebrowser
+   ============================================================ */
 
 #filebrowser {
-    background-color: #fff;
+    background-color: var(--sidebar-bg);
 }
 
 #fbheader {
     display: block;
     cursor: initial;
     pointer-events: none;
-    color: #424242 !important;
+    color: var(--sidebar-header) !important;
     font-weight: 400;
     font-size: .9em;
     min-height: 64px;
@@ -66,7 +356,7 @@ main {
 #fbheaderbranch {
     padding: 5px 10px !important;
     display: none;
-    color: #757575 !important;
+    color: var(--text-muted) !important;
 }
 
 #branchselector {
@@ -83,16 +373,16 @@ a.branch_select.active {
 }
 
 a.collection-item {
-    color: #616161 !important;
+    color: var(--sidebar-text) !important;
 }
 
 .fbtoolbarbutton {
-    color: #757575 !important;
+    color: var(--text-muted) !important;
     min-height: 64px !important;
 }
 
 .fbmenubutton {
-    color: #616161 !important;
+    color: var(--sidebar-text) !important;
     display: inline-block;
     float: right;
     min-height: 64px;
@@ -101,13 +391,220 @@ a.collection-item {
 }
 
 .filename {
-    color: #616161 !important;
+    color: var(--sidebar-text) !important;
     font-weight: 400;
     display: inline-block;
     width: 182px;
     white-space: nowrap;
     text-overflow: ellipsis;
     cursor: pointer;
+}
+
+.collection {
+    margin: 0;
+    background-color: var(--sidebar-bg);
+}
+
+li.collection-item {
+    border-bottom: 1px solid var(--sidebar-border) !important;
+    background-color: var(--sidebar-bg) !important;
+    color: var(--sidebar-text) !important;
+}
+
+li.collection-item:hover,
+li.collection-item.active {
+    background-color: var(--surface-alt) !important;
+}
+
+.collection-item #uplink {
+    background-color: var(--bg-alt);
+    width: 323px !important;
+    margin-left: -3px !important;
+}
+
+/* ============================================================
+   Side nav / slide-out
+   ============================================================ */
+
+.side-nav,
+#slide-out {
+    background-color: var(--sidebar-bg) !important;
+    width: 337px !important;
+    height: 100% !important;
+}
+
+.fb_side-nav li {
+    line-height: 36px;
+}
+
+.fb_side-nav a {
+    padding: 0 0 0 16px;
+    display: inline-block !important;
+    color: var(--sidebar-text) !important;
+}
+
+.fb_side-nav li > a > i {
+    margin-right: 16px !important;
+    cursor: pointer;
+}
+
+/* ============================================================
+   Collapsible / Ace settings panel
+   ============================================================ */
+
+.collapsible {
+    background-color: var(--surface) !important;
+    border: 1px solid var(--border) !important;
+}
+
+.collapsible-header {
+    background-color: var(--surface) !important;
+    color: var(--text-dark) !important;
+    border-bottom: 1px solid var(--border) !important;
+}
+
+.collapsible-header:hover {
+    background-color: var(--surface-alt) !important;
+}
+
+.collapsible-body {
+    background-color: var(--surface) !important;
+    color: var(--text) !important;
+    border-bottom: 1px solid var(--border) !important;
+}
+
+.collapsible-body label,
+.collapsible-body span {
+    color: var(--text) !important;
+}
+
+/* ============================================================
+   Modals
+   ============================================================ */
+
+.modal {
+    background-color: var(--modal-bg) !important;
+    color: var(--modal-text) !important;
+}
+
+.modal .modal-content,
+.modal .modal-footer {
+    background-color: var(--modal-bg) !important;
+    color: var(--modal-text) !important;
+}
+
+.modal .modal-footer {
+    border-top: 1px solid var(--border) !important;
+}
+
+.modal h4, .modal h5, .modal p, .modal label {
+    color: var(--modal-text) !important;
+}
+
+#modal_acekeyboard {
+    top: auto;
+    width: 96%;
+    min-height: 96%;
+    border-radius: 0;
+    margin: auto;
+}
+
+.modal .modal-content_nopad {
+    padding: 0;
+}
+
+/* ============================================================
+   Forms / Inputs inside modals and panels
+   ============================================================ */
+
+input[type=text],
+input[type=password],
+textarea,
+select {
+    color: var(--text-dark) !important;
+    background-color: transparent !important;
+}
+
+input.currentfile_input {
+    margin-bottom: 0;
+    margin-top: 0;
+    padding-left: 5px;
+    border-bottom: 0;
+    color: var(--text-dark) !important;
+}
+
+label {
+    color: var(--text-muted) !important;
+}
+
+.input-field input:focus + label,
+.input-field textarea:focus + label {
+    color: var(--accent) !important;
+}
+
+.input-field input[type=text].valid,
+.input-field input[type=text]:focus,
+.input-field input[type=password].valid,
+.input-field input[type=password]:focus,
+.input-field textarea:focus {
+    border-bottom: 1px solid var(--accent) !important;
+    box-shadow: 0 1px 0 0 var(--accent) !important;
+}
+
+.select-wrapper input.select-dropdown {
+    width: 96%;
+    overflow: hidden;
+    direction: ltr;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-dark) !important;
+}
+
+/* Checkbox colors */
+.blue_check:checked + label:before {
+    border-right: 2px solid var(--accent);
+    border-bottom: 2px solid var(--accent);
+}
+
+/* ============================================================
+   Footer
+   ============================================================ */
+
+footer {
+    z-index: 10;
+    background-color: var(--surface) !important;
+    color: var(--text) !important;
+}
+
+/* ============================================================
+   Misc layout
+   ============================================================ */
+
+#editor {
+    position: fixed;
+    top: 135px;
+    right: 0;
+    bottom: 0;
+}
+
+@media only screen and (max-width: 600px) {
+    #editor {
+        top: 125px;
+    }
+    .toolbar_mobile {
+        margin-bottom: 0;
+    }
+}
+
+.leftellipsis {
+    overflow: hidden;
+    direction: rtl;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+#edit_float {
+    z-index: 10;
 }
 
 .nowrap {
@@ -126,22 +623,9 @@ span.stats {
     margin: -10px 0 0 0;
     padding: 0;
     font-size: 0.5em;
-    color: #616161 !important;
+    color: var(--text) !important;
     line-height: 16px;
     display: inherit;
-}
-
-.collection-item #uplink {
-    background-color: #f5f5f5;
-    width: 323px !important;
-    margin-left: -3px !important;
-}
-
-input.currentfile_input {
-    margin-bottom: 0;
-    margin-top: 0;
-    padding-left: 5px;
-    border-bottom: 0;
 }
 
 .side_tools {
@@ -150,34 +634,6 @@ input.currentfile_input {
 
 .fbtoolbarbutton_icon {
     margin-top: 20px;
-}
-
-.collection {
-    margin: 0;
-    background-color: #fff;
-}
-
-li.collection-item {
-    border-bottom: 1px solid #eeeeee !important;
-}
-
-.side-nav {
-    width: 337px !important;
-    height: 100% !important;
-}
-
-.fb_side-nav li {
-    line-height: 36px;
-}
-
-.fb_side-nav a {
-  padding: 0 0 0 16px;
-  display: inline-block !important;
-}
-
-.fb_side-nav li>a>i {
-    margin-right: 16px !important;
-    cursor: pointer;
 }
 
 .green {
@@ -196,247 +652,8 @@ li.collection-item {
     min-width: 140px !important;
 }
 
-.dropdown-content li>a,
-.dropdown-content li>span {
-    color: #616161 !important;
-}
-
 .fb_dd {
     margin-left: -15px !important;
-}
-
-.blue_check:checked+label:before {
-    border-right: 2px solid #03a9f4;
-    border-bottom: 2px solid #03a9f4;
-}
-
-.input-field input:focus+label {
-    color: #03a9f4 !important;
-}
-
-.input-field input[type=text].valid {
-    border-bottom: 1px solid #03a9f4 !important;
-    box-shadow: 0 1px 0 0 #03a9f4 !important;
-}
-
-.input-field input[type=text]:focus {
-    border-bottom: 1px solid #03a9f4 !important;
-    box-shadow: 0 1px 0 0 #03a9f4 !important;
-}
-
-.input-field input:focus+label {
-    color: #03a9f4 !important;
-}
-
-.input-field input[type=password].valid {
-    border-bottom: 1px solid #03a9f4 !important;
-    box-shadow: 0 1px 0 0 #03a9f4 !important;
-}
-
-.input-field input[type=password]:focus {
-    border-bottom: 1px solid #03a9f4 !important;
-    box-shadow: 0 1px 0 0 #03a9f4 !important;
-}
-
-.input-field textarea:focus+label {
-    color: #03a9f4 !important;
-}
-
-.input-field textarea:focus {
-    border-bottom: 1px solid #03a9f4 !important;
-    box-shadow: 0 1px 0 0 #03a9f4 !important;
-}
-
-#modal_acekeyboard {
-    top: auto;
-    width: 96%;
-    min-height: 96%;
-    border-radius: 0;
-    margin: auto;
-}
-
-.modal .modal-content_nopad {
-    padding: 0;
-}
-
-.waves-effect.waves-blue .waves-ripple {
-    background-color: #03a9f4;
-}
-
-.preloader-background {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background-color: #eee;
-    position: fixed;
-    z-index: 10000;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-}
-
-.modal-content_nopad {
-    position: relative;
-}
-
-.modal-content_nopad .modal_btn {
-    position: absolute;
-    top: 2px;
-    right:0;
-}
-
-footer {
-    z-index: 10;
-}
-
-.shadow {
-    height: 25px;
-    margin: -26px;
-    min-width: 320px;
-    background-color: transparent;
-}
-
-.ace_optionsMenuEntry input {
-    position: relative !important;
-    left: 0 !important;
-    opacity: 1 !important;
-}
-
-.ace_optionsMenuEntry select {
-    position: relative !important;
-    left: 0 !important;
-    opacity: 1 !important;
-    display: block !important;
-}
-
-.ace_search {
-    background-color: #eeeeee !important;
-    border-radius: 0 !important;
-    border: 0 !important;
-    box-shadow: 0 6px 10px 0 rgba(0, 0, 0, 0.14), 0 1px 18px 0 rgba(0, 0, 0, 0.12), 0 3px 5px -1px rgba(0, 0, 0, 0.3);
-}
-
-.ace_search_form {
-    background-color: #fafafa;
-    width: 300px;
-    border: 0 !important;
-    border-radius: 0 !important;
-    outline: none !important;
-    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 2px 1px -2px rgba(0, 0, 0, 0.2);
-    margin-bottom: 15px !important;
-    margin-left: 8px !important;
-    color: #424242 !important;
-}
-
-.ace_search_field {
-    padding-left: 4px !important;
-    margin-left: 10px !important;
-    max-width: 275px !important;
-    font-family: 'Roboto', sans-serif !important;
-    border-bottom: 1px solid #03a9f4 !important;
-    color: #424242 !important;
-}
-
-.ace_replace_form {
-    background-color: #fafafa;
-    width: 300px;
-    border: 0 !important;
-    border-radius: 0 !important;
-    outline: none !important;
-    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 2px 1px -2px rgba(0, 0, 0, 0.2);
-    margin-bottom: 15px !important;
-    margin-left: 8px !important;
-}
-
-.ace_search_options {
-    background-color: #eeeeee;
-    text-align: left !important;
-    letter-spacing: .5px !important;
-    transition: .2s ease-out;
-    font-family: 'Roboto', sans-serif !important;
-    font-size: 130%;
-    top: 0 !important;
-}
-
-.ace_searchbtn {
-    text-decoration: none !important;
-    min-width: 40px !important;
-    min-height: 30px !important;
-    color: #424242 !important;
-    text-align: center !important;
-    letter-spacing: .5px !important;
-    transition: .2s ease-out;
-    cursor: pointer;
-    font-family: 'Roboto', sans-serif !important;
-}
-
-.ace_searchbtn:hover {
-    background-color: #03a9f4;
-}
-
-.ace_replacebtn {
-    text-decoration: none !important;
-    min-width: 40px !important;
-    min-height: 30px !important;
-    color: #424242 !important;
-    text-align: center !important;
-    letter-spacing: .5px !important;
-    transition: .2s ease-out;
-    cursor: pointer;
-    font-family: 'Roboto', sans-serif !important;
-}
-
-.ace_replacebtn:hover {
-    background-color: #03a9f4;
-}
-
-.ace_button {
-    text-decoration: none !important;
-    min-width: 40px !important;
-    min-height: 30px !important;
-    border-radius: 0 !important;
-    outline: none !important;
-    color: #424242 !important;
-    background-color: #fafafa;
-    text-align: center;
-    letter-spacing: .5px;
-    transition: .2s ease-out;
-    cursor: pointer;
-    font-family: 'Roboto', sans-serif !important;
-}
-
-.ace_button:hover {
-    background-color: #03a9f4 !important;
-}
-
-.ace_invisible {
-    color: rgba(191, 191, 191, 0.5) !important;
-}
-
-.fbicon_pad {
-    min-height: 64px !important;
-}
-
-.fbmenuicon_pad {
-    min-height: 64px;
-    margin-top: 6px !important;
-    margin-right: 18px !important;
-    color: #616161 !important;
-}
-
-.no-padding {
-    padding: 0 !important;
-}
-
-.branch_select {
-    min-width: 300px !important;
-    font-size: 14px !important;
-    font-weight: 400 !important;
-}
-
-a.branch_hover:hover {
-    background-color: #e0e0e0 !important;
 }
 
 .hidesave {
@@ -454,14 +671,14 @@ a.branch_hover:hover {
 }
 
 @-webkit-keyframes fadeinout {
-    0% { background-color: #f5f5f5; }
-    50% { background-color: #ff8a80; }
-    100% { background-color: #f5f5f5; }
+    0%   { background-color: var(--bg-alt); }
+    50%  { background-color: #ff8a80; }
+    100% { background-color: var(--bg-alt); }
 }
 @keyframes fadeinout {
-    0% { background-color: #f5f5f5; }
-    50% { background-color: #ff8a80; }
-    100% { background-color: #f5f5f5; }
+    0%   { background-color: var(--bg-alt); }
+    50%  { background-color: #ff8a80; }
+    100% { background-color: var(--bg-alt); }
 }
 
 #lint-status {
@@ -481,4 +698,210 @@ a.branch_hover:hover {
 #modal_lint textarea {
     resize: none;
     height: auto;
+}
+
+/* ============================================================
+   Preloader
+   ============================================================ */
+
+.preloader-background {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--bg);
+    position: fixed;
+    z-index: 10000;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}
+
+/* ============================================================
+   Ace search UI
+   ============================================================ */
+
+.ace_search {
+    background-color: var(--ace-search-bg) !important;
+    border-radius: 0 !important;
+    border: 0 !important;
+    box-shadow: 0 6px 10px 0 var(--shadow-color), 0 1px 18px 0 var(--shadow-color), 0 3px 5px -1px rgba(0,0,0,0.3);
+}
+
+.ace_search_form {
+    background-color: var(--search-form-bg);
+    width: 300px;
+    border: 0 !important;
+    border-radius: 0 !important;
+    outline: none !important;
+    box-shadow: 0 2px 2px 0 var(--shadow-color), 0 1px 5px 0 var(--shadow-color), 0 2px 1px -2px rgba(0,0,0,0.2);
+    margin-bottom: 15px !important;
+    margin-left: 8px !important;
+    color: var(--search-text) !important;
+}
+
+.ace_search_field {
+    padding-left: 4px !important;
+    margin-left: 10px !important;
+    max-width: 275px !important;
+    font-family: 'Roboto', sans-serif !important;
+    border-bottom: 1px solid var(--accent) !important;
+    color: var(--search-text) !important;
+}
+
+.ace_replace_form {
+    background-color: var(--search-form-bg);
+    width: 300px;
+    border: 0 !important;
+    border-radius: 0 !important;
+    outline: none !important;
+    box-shadow: 0 2px 2px 0 var(--shadow-color), 0 1px 5px 0 var(--shadow-color), 0 2px 1px -2px rgba(0,0,0,0.2);
+    margin-bottom: 15px !important;
+    margin-left: 8px !important;
+}
+
+.ace_search_options {
+    background-color: var(--surface-alt);
+    text-align: left !important;
+    letter-spacing: .5px !important;
+    transition: .2s ease-out;
+    font-family: 'Roboto', sans-serif !important;
+    font-size: 130%;
+    top: 0 !important;
+}
+
+.ace_searchbtn {
+    text-decoration: none !important;
+    min-width: 40px !important;
+    min-height: 30px !important;
+    color: var(--search-text) !important;
+    text-align: center !important;
+    letter-spacing: .5px !important;
+    transition: .2s ease-out;
+    cursor: pointer;
+    font-family: 'Roboto', sans-serif !important;
+}
+
+.ace_searchbtn:hover {
+    background-color: var(--accent);
+}
+
+.ace_replacebtn {
+    text-decoration: none !important;
+    min-width: 40px !important;
+    min-height: 30px !important;
+    color: var(--search-text) !important;
+    text-align: center !important;
+    letter-spacing: .5px !important;
+    transition: .2s ease-out;
+    cursor: pointer;
+    font-family: 'Roboto', sans-serif !important;
+}
+
+.ace_replacebtn:hover {
+    background-color: var(--accent);
+}
+
+.ace_button {
+    text-decoration: none !important;
+    min-width: 40px !important;
+    min-height: 30px !important;
+    border-radius: 0 !important;
+    outline: none !important;
+    color: var(--search-text) !important;
+    background-color: var(--search-form-bg);
+    text-align: center;
+    letter-spacing: .5px;
+    transition: .2s ease-out;
+    cursor: pointer;
+    font-family: 'Roboto', sans-serif !important;
+}
+
+.ace_button:hover {
+    background-color: var(--accent) !important;
+}
+
+.ace_invisible {
+    color: rgba(191, 191, 191, 0.5) !important;
+}
+
+.ace_optionsMenuEntry input {
+    position: relative !important;
+    left: 0 !important;
+    opacity: 1 !important;
+}
+
+.ace_optionsMenuEntry select {
+    position: relative !important;
+    left: 0 !important;
+    opacity: 1 !important;
+    display: block !important;
+}
+
+/* ============================================================
+   Misc icon sizing
+   ============================================================ */
+
+.fbicon_pad {
+    min-height: 64px !important;
+}
+
+.fbmenuicon_pad {
+    min-height: 64px;
+    margin-top: 6px !important;
+    margin-right: 18px !important;
+    color: var(--sidebar-text) !important;
+}
+
+.no-padding {
+    padding: 0 !important;
+}
+
+.branch_select {
+    min-width: 300px !important;
+    font-size: 14px !important;
+    font-weight: 400 !important;
+}
+
+a.branch_hover:hover {
+    background-color: var(--sidebar-hover) !important;
+}
+
+.shadow {
+    height: 25px;
+    margin: -26px;
+    min-width: 320px;
+    background-color: transparent;
+}
+
+.modal-content_nopad {
+    position: relative;
+}
+
+.modal-content_nopad .modal_btn {
+    position: absolute;
+    top: 2px;
+    right: 0;
+}
+
+/* ============================================================
+   Theme toggle icon in navbar
+   ============================================================ */
+
+#theme_toggle_btn {
+    cursor: pointer;
+    padding-left: 20px !important;
+    padding-right: 20px !important;
+}
+
+/* Smooth color transitions on theme switch */
+body, nav, .side-nav, #slide-out, .dropdown-content,
+.collapsible, .collapsible-header, .collapsible-body,
+.modal, li.collection-item, .collection {
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+/* Waves button overrides to follow theme accent */
+.waves-effect.waves-blue .waves-ripple {
+    background-color: var(--accent);
 }


### PR DESCRIPTION
## Problem
 
Selecting a dark theme in Editor Settings only applies to the Ace editor
text area. The surrounding UI shell — navbar, sidebar, filepath bar, left
HA-entities panel, dropdowns and modals — always stays white/light-grey.
 
This has been an open issue since 2020:
- https://github.com/home-assistant/addons/issues/1370
- https://github.com/home-assistant/addons/issues/3449
 
A second pain point: editor settings are stored in `localStorage`, which
is scoped to the browser origin **and path**. Because the configurator
runs behind HA Ingress, the path includes a session token that can change
on add-on restarts. When that happens, all stored settings (including the
chosen Ace theme) are silently lost.
 
## Solution
 
### 1. CSS custom properties (variables)
 
`style.css` is refactored to use CSS custom properties for every color
value. Three rule-sets define the full palette:
 
| Selector | When active |
|---|---|
| `:root` | light mode (default) |
| `[data-theme="dark"]` | explicit dark mode |
| `:root:not([data-theme="light"]):not([data-theme="dark"])` inside `@media (prefers-color-scheme: dark)` | OS dark mode when no explicit choice is set |
 
All Materialize utility classes that are hard-coded in the HTML
(`grey lighten-4`, `light-blue`, etc.) are overridden with `!important`
where necessary so the entire UI follows the active theme.
 
### 2. Three-way theme toggle
 
A **"Theme: Auto / Light / Dark"** entry is added to both the desktop and
mobile settings dropdowns. Clicking it cycles through the three modes and
updates a matching Material icon (`brightness_auto`, `brightness_high`,
`brightness_2`).
 
### 3. Server-side persistence
 
Theme preference is saved to **`.hass_configurator_prefs.json`** inside
`BASEPATH` (the `/config` directory). This file is read at render time and
the chosen mode is injected directly into the HTML `<html data-theme="…">`
attribute, so:
 
- The correct theme is applied **before first paint** — no flash.
- The setting is **device-independent**: every browser that opens the
  same HA instance gets the same theme automatically.
- It survives Ingress token rotation, add-on restarts and browser cache
  clears.
 
Two new lightweight endpoints handle persistence:
 
```
GET  /api/prefs   → {"ui_theme": "auto"}
POST /api/prefs   ← {"ui_theme": "dark"}
```
 
### 4. Ace theme auto-sync
 
When the UI theme is switched, the Ace editor theme is automatically
updated to match (`monokai` for dark, `chrome` for light). Users can
still override the Ace theme manually via Editor Settings at any time.
 
### 5. OS preference listener
 
A `matchMedia` listener updates the rendered colors in real time if the
OS switches dark/light while the tab is open and the mode is `auto`.
 
## Files changed
 
| File | Changes |
|---|---|
| `hass_configurator/style.css` | Refactored to CSS variables; dark palette; Materialize overrides |
| `hass_configurator/dev.html` | `data-theme` on `<html>`; theme toggle in menus; `applyTheme()` / `cycleTheme()` JS |
| `hass_configurator/configurator.py` | `load_prefs()` / `save_prefs()`; GET+POST `/api/prefs`; `$ui_theme` template variable |
 
## Testing
 
Tested on:
- Home Assistant OS (aarch64) with File Editor 5.8.0
- Desktop browser (Chrome, Safari, Firefox) and HA Companion Android app
- All three modes (auto / light / dark) including OS-level switching
- Preference persistence across browser sessions and devices
 
## Screenshots
 
| Light mode | Dark mode |
|---|---|
| *(original behavior)* | Navbar, sidebar, filepath bar, HA-entities panel, dropdowns, modals all dark |

<img width="1437" height="814" alt="Darkmode_Chrome_Browser" src="https://github.com/user-attachments/assets/82131bfa-ab7a-4321-9327-ac2d67c43016" />
<img width="1437" height="814" alt="Lightmode_Chrome_Browser" src="https://github.com/user-attachments/assets/02de1701-50de-4635-bf94-e6a19b770f94" />


![Darkmode_Android_Companion-App_1](https://github.com/user-attachments/assets/8f7583ea-3727-4800-960d-609cd1b640ed)
![Darkmode_Android_Companion-App_2](https://github.com/user-attachments/assets/3dfe95fe-218c-49a2-96cb-fcaf12c806ee)

## Using this patch without merging

If you want to use this today without waiting for a merge, here is a
manual installation guide for Home Assistant OS.

### 1. Download the three changed files

Download `configurator.py`, `dev.html` and `style.css` from this branch
and place them in `/config/custom_fileeditor/`
(e.g. via Samba or the
File Editor itself).
> **Note:** On HAOS the path is `/homeassistant/` instead of `/config/`. 
> This applies to all paths mentioned in this guide.

### 2. Create a patch script

Create `/config/custom_fileeditor/patch_fileeditor.sh`:
```bash
#!/bin/bash
TARGET=/usr/lib/python3.11/site-packages/hass_configurator
SOURCE=/config/custom_fileeditor

docker cp $SOURCE/configurator.py addon_core_configurator:$TARGET/configurator.py
docker cp $SOURCE/dev.html        addon_core_configurator:$TARGET/dev.html
docker cp $SOURCE/style.css       addon_core_configurator:$TARGET/style.css

PID=$(docker exec addon_core_configurator pgrep -f hass-configurator)
docker exec addon_core_configurator kill -HUP $PID
```

### 3. Apply the patch

- Run the script once in your SSH terminal:
/config/custom_fileeditor/patch_fileeditor.sh

- Maybe hard-reload your browser (Cmd/Ctrl+Shift+R).

Important: The shell_command integration in HA automations cannot access docker because it runs inside the HA Core container, not on the host. The script must be run manually in an SSH terminal.

### 4. Re-applying after updates

The patch needs to be re-applied after every File Editor add-on update since updates replace the container image. Simply re-run the script from step 3.
The theme preference (stored in /config/.hass_configurator_prefs.json) survives updates and never needs to be reset.
