### PR TITLE
Handle SIGTERM for clean shutdown

### DIFF
--- a/configurator.py
+++ b/configurator.py
@@ -5102,6 +5102,7 @@ def main():
     """Main function, duh!"""
     global HTTPD
     signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
     parser = argparse.ArgumentParser(description="Visit " \
     "https://github.com/danielperna84/hass-configurator for more details " \
     "about the availble options.")


### PR DESCRIPTION
Register the existing signal_handler for SIGTERM in addition to SIGINT so that the app stops quickly and Supervisor does not consider a manual app stop as failure.

Related to: https://github.com/home-assistant/supervisor/issues/6840